### PR TITLE
Fixed #78 in nwoolls/MultiMiner

### DIFF
--- a/MultiMiner.Win/MinerSettingsForm.Designer.cs
+++ b/MultiMiner.Win/MinerSettingsForm.Designer.cs
@@ -258,6 +258,7 @@
             "15 minutes",
             "30 minutes",
             "1 hour",
+            "2 hours",
             "3 hours",
             "6 hours",
             "12 hours"});


### PR DESCRIPTION
Fixed #78: Restart miners every doesn't work right if set for >1 hour
Added a "2 hours option" in the intervalCombo control.
